### PR TITLE
Compatibility Improvements

### DIFF
--- a/src/main/resources/data/carbonize/tags/items/consume_igniters.json
+++ b/src/main/resources/data/carbonize/tags/items/consume_igniters.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:fire_charge"
+  ]
+}

--- a/src/main/resources/data/carbonize/tags/items/damage_igniters.json
+++ b/src/main/resources/data/carbonize/tags/items/damage_igniters.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:flint_and_steel"
+  ]
+}

--- a/src/main/resources/data/carbonize/tags/items/igniters.json
+++ b/src/main/resources/data/carbonize/tags/items/igniters.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "#carbonize:consume_igniters",
+    "#carbonize:damage_igniters"
+  ]
+}


### PR DESCRIPTION
Had to restart this PR because git decided to do the opposite of what I wanted it to do,

copy-paste from the previous pr:

To clear up any confusion, the unified tag carbonize:igniters is just to ensure that only one tag is checked for the event to avoid unnecessary overhead. Let me know if you want me to change anything. :)

Changes:

Flint and Steel replaced with a tag
Charcoal Pit ingredients replaced with tag; can support more than just logs now.